### PR TITLE
Refactored all references to old `tests` namespace to use correct     namespace.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "darling/php-reflection-utilities",
-            "version": "v1.0.3",
+            "version": "v1.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sevidmusic/PHPReflectionUtilities.git",
-                "reference": "30dd67cca543e872b3fac3498b85ed80ff5d64ca"
+                "reference": "90cb4af2ada49d43b9c08ebefdabc1ccebb2a0ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sevidmusic/PHPReflectionUtilities/zipball/30dd67cca543e872b3fac3498b85ed80ff5d64ca",
-                "reference": "30dd67cca543e872b3fac3498b85ed80ff5d64ca",
+                "url": "https://api.github.com/repos/sevidmusic/PHPReflectionUtilities/zipball/90cb4af2ada49d43b9c08ebefdabc1ccebb2a0ac",
+                "reference": "90cb4af2ada49d43b9c08ebefdabc1ccebb2a0ac",
                 "shasum": ""
             },
             "require": {
@@ -49,22 +49,22 @@
             "description": "A collection of php classes that can be used to aide in reflection with PHP",
             "support": {
                 "issues": "https://github.com/sevidmusic/PHPReflectionUtilities/issues",
-                "source": "https://github.com/sevidmusic/PHPReflectionUtilities/tree/v1.0.3"
+                "source": "https://github.com/sevidmusic/PHPReflectionUtilities/tree/v1.0.4"
             },
-            "time": "2023-03-01T23:39:50+00:00"
+            "time": "2023-03-18T05:15:06+00:00"
         },
         {
             "name": "darling/php-text-types",
-            "version": "v1.0.5",
+            "version": "v1.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sevidmusic/PHPTextTypes.git",
-                "reference": "305b226a857fb58c3ed8535d383f10ec64152825"
+                "reference": "a44ea7dde3ee6976c3639d12ac419a8ff008d4c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sevidmusic/PHPTextTypes/zipball/305b226a857fb58c3ed8535d383f10ec64152825",
-                "reference": "305b226a857fb58c3ed8535d383f10ec64152825",
+                "url": "https://api.github.com/repos/sevidmusic/PHPTextTypes/zipball/a44ea7dde3ee6976c3639d12ac419a8ff008d4c4",
+                "reference": "a44ea7dde3ee6976c3639d12ac419a8ff008d4c4",
                 "shasum": ""
             },
             "require": {
@@ -78,8 +78,8 @@
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "tests\\": "tests/",
-                    "Darling\\PHPTextTypes\\": "src/"
+                    "Darling\\PHPTextTypes\\": "src/",
+                    "Darling\\PHPTextTypes\\Tests\\": "tests/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -95,22 +95,22 @@
             "description": "A collection of classes that represent various types of text.",
             "support": {
                 "issues": "https://github.com/sevidmusic/PHPTextTypes/issues",
-                "source": "https://github.com/sevidmusic/PHPTextTypes/tree/v1.0.5"
+                "source": "https://github.com/sevidmusic/PHPTextTypes/tree/v1.0.7"
             },
-            "time": "2023-03-01T23:34:07+00:00"
+            "time": "2023-03-20T17:59:11+00:00"
         },
         {
             "name": "darling/php-unit-test-utilities",
-            "version": "v1.0.4",
+            "version": "v1.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sevidmusic/PHPUnitTestUtilities.git",
-                "reference": "85bc9830ee93316120ba072503a803bad34d282b"
+                "reference": "8f82773c5d66c39587f5ce630b9bfc25aef207b9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sevidmusic/PHPUnitTestUtilities/zipball/85bc9830ee93316120ba072503a803bad34d282b",
-                "reference": "85bc9830ee93316120ba072503a803bad34d282b",
+                "url": "https://api.github.com/repos/sevidmusic/PHPUnitTestUtilities/zipball/8f82773c5d66c39587f5ce630b9bfc25aef207b9",
+                "reference": "8f82773c5d66c39587f5ce630b9bfc25aef207b9",
                 "shasum": ""
             },
             "require": {
@@ -140,9 +140,9 @@
             "description": "A collection of traits that define methods to aide in the implementation of phpunit tests.",
             "support": {
                 "issues": "https://github.com/sevidmusic/PHPUnitTestUtilities/issues",
-                "source": "https://github.com/sevidmusic/PHPUnitTestUtilities/tree/v1.0.4"
+                "source": "https://github.com/sevidmusic/PHPUnitTestUtilities/tree/v1.0.5"
             },
-            "time": "2023-03-18T04:08:21+00:00"
+            "time": "2023-03-18T04:20:58+00:00"
         }
     ],
     "packages-dev": [
@@ -754,16 +754,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.0.16",
+            "version": "10.0.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "07d386a11ac7094032900f07cada1c8975d16607"
+                "reference": "b75eddcabca052312ae38c8a2bc69ff1a7b89b77"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/07d386a11ac7094032900f07cada1c8975d16607",
-                "reference": "07d386a11ac7094032900f07cada1c8975d16607",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b75eddcabca052312ae38c8a2bc69ff1a7b89b77",
+                "reference": "b75eddcabca052312ae38c8a2bc69ff1a7b89b77",
                 "shasum": ""
             },
             "require": {
@@ -834,7 +834,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.0.16"
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.0.17"
             },
             "funding": [
                 {
@@ -850,7 +851,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-13T09:02:40+00:00"
+            "time": "2023-03-20T14:42:33+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/tests/classes/strings/JsonStringTest.php
+++ b/tests/classes/strings/JsonStringTest.php
@@ -4,7 +4,7 @@ namespace Darling\PHPJsonUtilities\tests\classes\strings;
 
 use Darling\PHPJsonUtilities\classes\strings\JsonString;
 use Darling\PHPJsonUtilities\tests\interfaces\strings\JsonStringTestTrait;
-use tests\classes\strings\TextTest;
+use Darling\PHPTextTypes\Tests\classes\strings\TextTest;
 
 class JsonStringTest extends TextTest
 {

--- a/tests/interfaces/strings/JsonStringTestTrait.php
+++ b/tests/interfaces/strings/JsonStringTestTrait.php
@@ -2,7 +2,7 @@
 
 namespace Darling\PHPJsonUtilities\tests\interfaces\strings;
 
-use tests\interfaces\strings\TextTestTrait;
+use Darling\PHPTextTypes\Tests\interfaces\strings\TextTestTrait;
 
 trait JsonStringTestTrait
 {


### PR DESCRIPTION
commit 9f9b620512e8640f278f1184a5c2edfcea71d80a (HEAD -> PHPJsonUtilities1679347905, origin/PHPJsonUtilities1679347905)
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Mon Mar 20 17:42:52 2023 -0400

    Various Darling libraries changed their use of the tests namespace
    to instead follow the naming convention:

    ```
    Darling\LIBRARYNAME\Tests
    ```

    Refactored all references to old `tests` namespace to use correct
    namespace.