### PR TITLE
Working on `draftOfPhpJsonUtilities.php`

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1155,16 +1155,16 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "5.0.0",
+            "version": "5.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "70dd1b20bc198da394ad542e988381b44e64e39f"
+                "reference": "aae9a0a43bff37bd5d8d0311426c87bf36153f02"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/70dd1b20bc198da394ad542e988381b44e64e39f",
-                "reference": "70dd1b20bc198da394ad542e988381b44e64e39f",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/aae9a0a43bff37bd5d8d0311426c87bf36153f02",
+                "reference": "aae9a0a43bff37bd5d8d0311426c87bf36153f02",
                 "shasum": ""
             },
             "require": {
@@ -1209,7 +1209,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/5.0.0"
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/5.0.1"
             },
             "funding": [
                 {
@@ -1217,7 +1218,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:00:31+00:00"
+            "time": "2023-03-23T05:12:41+00:00"
         },
         {
             "name": "sebastian/environment",

--- a/draftOfPhpJsonUtilities.php
+++ b/draftOfPhpJsonUtilities.php
@@ -4,6 +4,7 @@ include('/home/darling/Git/PHPJsonUtilities/vendor/autoload.php');
 
 use \Darling\PHPReflectionUtilities\classes\utilities\ObjectReflection;
 use \Darling\PHPReflectionUtilities\classes\utilities\Reflection;
+use \Darling\PHPReflectionUtilities\interfaces\utilities\Reflection as ReflectionInterface;
 use \Darling\PHPTextTypes\classes\strings\AlphanumericText;
 use \Darling\PHPTextTypes\classes\strings\Id;
 use \Darling\PHPTextTypes\classes\strings\Name;
@@ -253,6 +254,45 @@ final class JsonString extends Text
                 self::class
             );
         }
+        if(
+            is_object($this->originalValue)
+            &&
+            in_array(
+                Reflector::class,
+                class_implements($this->originalValue::class),
+            )
+        ) {
+            throw new RuntimeException(
+                self::class .
+                ' Error:' .
+                PHP_EOL .
+                'Cannot use a ' .
+                self::class .
+                ' to encode an object that ' .
+                'is an implementation of a ' .
+                Reflector::class
+            );
+        }
+
+        if(
+            is_object($this->originalValue)
+            &&
+            in_array(
+                ReflectionInterface::class,
+                class_implements($this->originalValue::class),
+            )
+        ) {
+            throw new RuntimeException(
+                self::class .
+                ' Error:' .
+                PHP_EOL .
+                'Cannot use a ' .
+                self::class .
+                ' to encode an object that ' .
+                'is an implementation of a ' .
+                ReflectionInterface::class
+            );
+        }
     }
 
     protected function encodeOriginalValueAsJson(): string
@@ -373,35 +413,32 @@ class JsonStringDecoder
 
 }
 
-$jsonStringDecoder = new JsonStringDecoder();
-
 $testObjects = [
-    new JsonString(new JsonString(new Id())), // FAILS : Solution: Do not allow JsonStrings to represent/encode other JsonStrings
-#    new AlphanumericText(new Text('AlphanumericText')),
-#    new Id(),
-#    new Name(new Text('Name')),
-#    new SafeText(new Text('SafeText')),
-#    new Text('Text'),
-#    new UnknownClass(),
-#    new PrivateMethods(),
+    new AlphanumericText(new Text('AlphanumericText')),
+    new Id(),
+    new Name(new Text('Name')),
+    new SafeText(new Text('SafeText')),
+    new Text('Text'),
+    new UnknownClass(),
+    new PrivateMethods(),
 ];
 
 $testObject = $testObjects[array_rand($testObjects)];
 
 $testJsonString = new JsonString($testObject);
 
+$jsonStringDecoder = new JsonStringDecoder();
+
 $decodedTestObject = $jsonStringDecoder->decodeJsonToObject(
     $testJsonString
 );
+
 var_dump(
     '$decodedTestObject matches $testObject',
     $decodedTestObject == $testObject
 );
 
-/*
-// save json for later viewing/debugging
 file_put_contents(
     '/tmp/darlingTestJson.json',
     $testJsonString->__toString()
 );
-*/


### PR DESCRIPTION
commit f3b1eaa7d0461b7057544ec373fd8dbcbb646e91 (HEAD -> PHPJsonUtilities1679604706, origin/PHPJsonUtilities1679604706)
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Fri Mar 24 23:29:36 2023 -0400

    Working on `draftOfPhpJsonUtilities.php`

    Fixed value of `Mocker::INTEGER`, was `integer`, is now `int`.

    Refactored scope of `Mocker->reflectionClass()` to `private`.

    Default value for strings returned by
    `Mocker->generateMockClassMethodArguments()` is no longer a
    randomly generated string of characters. Instead a `SafeText`
    instance is used to generate the default string.

    The `Mocker->generateMockClassMethodArguments()` method
    now throws an error if any arguments could not be mocked.

    `JsonStrings` no longer allow the encoding of a `Closure`.

    `JsonStrings` no longer allow the encoding of a `Directory`.

    Removed `hack` code that functioned as a temporary workaround to
    allow encoding/decoding of a `JsonSting`. `JsonSting`s are no
    longer allowed to be encoded as `JsonString`s.

    Defined new test classes.