### PR TITLE
Composer update. Fixed new phpstan issue.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -468,16 +468,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.22",
+            "version": "1.10.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "97d694dfd4ceb57bcce4e3b38548f13ea62e4287"
+                "reference": "65ab678d1248a8bc6fde456f0d7ff3562a61a4cd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/97d694dfd4ceb57bcce4e3b38548f13ea62e4287",
-                "reference": "97d694dfd4ceb57bcce4e3b38548f13ea62e4287",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/65ab678d1248a8bc6fde456f0d7ff3562a61a4cd",
+                "reference": "65ab678d1248a8bc6fde456f0d7ff3562a61a4cd",
                 "shasum": ""
             },
             "require": {
@@ -526,7 +526,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-06-30T20:04:11+00:00"
+            "time": "2023-07-04T13:32:44+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/src/classes/decoders/JsonDecoder.php
+++ b/src/classes/decoders/JsonDecoder.php
@@ -214,10 +214,14 @@ class JsonDecoder implements JsonDecoderInterface
     private function propertyDataOrEmptyArray(Json $json): array
     {
         $encodedData = $this->decodeJsonToArray($json);
-        return match(is_array($encodedData[Json::DATA_INDEX])) {
-            true => $encodedData[Json::DATA_INDEX],
-            default => [],
-        };
+        if(
+            isset($encodedData[Json::DATA_INDEX])
+            &&
+            is_array($encodedData[Json::DATA_INDEX])
+        ) {
+            return $encodedData[Json::DATA_INDEX];
+        }
+        return [];
     }
 
     /**


### PR DESCRIPTION
Fixed new phpstan issue in `src/classes/decoders/JsonDecoder.php`.

```
   Darling\PHPJsonUtilities\classes\decoders\JsonDecoder::propertyDataOrEmptyArray()
   should return array but returns mixed.

```

Issue began occurring after last composer update.